### PR TITLE
remove init and migrate from the setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ We strongly recommend to read through the first chapters of the [the flask mega 
 
 1. To initialise the database, run
   ```
-  $ poetry run flask db init
-  $ poetry run flask db migrate
   $ poetry run flask db upgrade
   ```
 


### PR DESCRIPTION
Now that we commited the first production version of the migrations dir, we don't need this anymore