### PR TITLE
Fix email query

### DIFF
--- a/member_database/queries.py
+++ b/member_database/queries.py
@@ -2,6 +2,10 @@ from .models.person import Person, User
 
 
 def get_user_by_name_or_email(name_or_email):
-    return User.query.filter(
-        (User.username == name_or_email) | (Person.email == name_or_email)
-    ).one_or_none()
+    return (
+        User.query
+        .join(Person)
+        .filter(
+            (User.username == name_or_email) | (Person.email == name_or_email)
+        ).one_or_none()
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "member-database"
-version = "0.3.7"
+version = "0.3.8"
 description = "Our PeP database solution for members and events"
 authors = ["Kevin Heinicke <kevin.heinicke@tu-dortmund.de>", "Maximilian Nöthe <maximilian.noethe@tu-dortmund.de>"]
 license = "MIT"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,6 +19,19 @@ def test_user():
     return u
 
 
+@pytest.fixture(scope='module')
+def test_user2():
+    from member_database.models import Person, User, db
+
+    p = Person(name='Marie Curie', email='marie.curie@tu-dortmund.de')
+    u = User(person=p, username='mcurie')
+
+    db.session.add(p, u)
+    db.session.commit()
+
+    return u
+
+
 def test_home(client):
     """
     Check if the index delivers a valid response
@@ -64,3 +77,14 @@ def test_password_reset(client, test_user):
 
     assert test_user.check_password(NEW_PW)
     assert not test_user.check_password(OLD_PW)
+
+
+def test_get_user(test_user, test_user2):
+    from member_database.queries import get_user_by_name_or_email
+
+    assert get_user_by_name_or_email(test_user.username).id == test_user.id
+    assert get_user_by_name_or_email(test_user.person.email).id == test_user.id
+
+
+    assert get_user_by_name_or_email(test_user2.username).id == test_user2.id
+    assert get_user_by_name_or_email(test_user2.person.email).id == test_user2.id


### PR DESCRIPTION
There was a missing `.join(Person)` in the query, so when given the email and not the username, every user in the db was returned and then `one_or_none` raised an error.

The test failed with current master but passes after the second commit in this branch.