### PR TITLE
Fix spacing of footer

### DIFF
--- a/member_database/templates/base_footer.html
+++ b/member_database/templates/base_footer.html
@@ -1,4 +1,4 @@
-<footer class="bg-light text-center text-lg-start mt-auto" style="font-size:16px;">
-  <a class="text-center p-3" href="https://pep-dortmund.org/ueber_uns/impressum.html">Impressum</a>
+<footer class="bg-light text-center text-lg-start mt-auto p-1">
+  <a class="text-center px-3" href="https://pep-dortmund.org/ueber_uns/impressum.html">Impressum</a>
   &copy; PeP et al. e.V. All rights reserved.
 </footer>


### PR DESCRIPTION
Footer had space below leading to an unnecessary scrollbar because of the padding in the impressum link.