### PR TITLE
Enable html rendering in form labels

### DIFF
--- a/member_database/events/json_forms.py
+++ b/member_database/events/json_forms.py
@@ -7,6 +7,7 @@ from wtforms.fields import (
     DecimalField,
 )
 from wtforms.validators import DataRequired, NumberRange, Regexp
+from markupsafe import Markup
 
 from ..widgets import LatexInput
 
@@ -16,7 +17,7 @@ def create_wtf_field(name, schema, required=True):
 
     kwargs = {
         "validators": validators,
-        "label": schema.get("label", name.title()),
+        "label": Markup(schema.get("label", name.title())),
     }
 
     message = schema.get("error_hint")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "member-database"
-version = "0.9.1"
+version = "0.9.2"
 description = "Our PeP database solution for members and events"
 authors = ["Kevin Heinicke <kevin.heinicke@tu-dortmund.de>", "Maximilian Linhoff <maximilian.linhoff@tu-dortmund.de>"]
 license = "MIT"


### PR DESCRIPTION
We deal with trusted input (only event admins can enter these) so this is safe against html injection.

This worked before, but since wtforms 2.3, label text is escaped and we need to explicitly allow the content.