### PR TITLE
Add support for default field values in json forms

### DIFF
--- a/member_database/events/json_forms.py
+++ b/member_database/events/json_forms.py
@@ -5,6 +5,7 @@ from wtforms.fields import (
     EmailField,
     IntegerField,
     DecimalField,
+    HiddenField,
 )
 from wtforms.validators import DataRequired, NumberRange, Regexp
 from markupsafe import Markup
@@ -16,6 +17,7 @@ def create_wtf_field(name, schema, required=True):
     validators = []
 
     kwargs = {
+        "default": schema.get("default"),
         "validators": validators,
         "label": Markup(schema.get("label", name.title())),
     }
@@ -71,6 +73,10 @@ def create_wtf_field(name, schema, required=True):
         if schema.get("const") is not None:
             validators.append(DataRequired())
         return wtforms.BooleanField(**kwargs)
+
+    # this can be used to show only a message
+    if schema["type"] == "hidden":
+        return HiddenField(**kwargs)
 
     # subform
     if schema["type"] == "object":

--- a/member_database/events/json_forms.py
+++ b/member_database/events/json_forms.py
@@ -5,7 +5,6 @@ from wtforms.fields import (
     EmailField,
     IntegerField,
     DecimalField,
-    HiddenField,
 )
 from wtforms.validators import DataRequired, NumberRange, Regexp
 from markupsafe import Markup
@@ -73,10 +72,6 @@ def create_wtf_field(name, schema, required=True):
         if schema.get("const") is not None:
             validators.append(DataRequired())
         return wtforms.BooleanField(**kwargs)
-
-    # this can be used to show only a message
-    if schema["type"] == "null":
-        return HiddenField(**kwargs)
 
     # subform
     if schema["type"] == "object":

--- a/member_database/events/json_forms.py
+++ b/member_database/events/json_forms.py
@@ -75,7 +75,7 @@ def create_wtf_field(name, schema, required=True):
         return wtforms.BooleanField(**kwargs)
 
     # this can be used to show only a message
-    if schema["type"] == "hidden":
+    if schema["type"] == "null":
         return HiddenField(**kwargs)
 
     # subform


### PR DESCRIPTION
For the 50-jahres-feier we want to show text below the form. Quick and dirty hack for this: use hidden field, settable by `"type": "null"`. 

Also, default values for integer fields are nice, so introduced "default"