### PR TITLE
Remove link to resend mail.

### DIFF
--- a/member_database/events/templates/events/registration.html
+++ b/member_database/events/templates/events/registration.html
@@ -18,10 +18,6 @@
 
   <h1>Anmeldung {{ event.name }}</h1>
 
-  <p> Falls du dich bereits für diese Veranstaltung angemeldet hast,
-  aber keine Email bekommen hast, kannst du sie <a href="{{ url_for('events.resend_emails') }}">
-  hier erneut anfordern</a>.
-
   {% if free_places %}
   <div class="alert alert-success">
     Es sind noch {{ free_places }} Plätze verfügbar.


### PR DESCRIPTION
* People probably don't remember anyway and just try to resend the form → get the button when trying to register again with the same mail
* Dean wanted to use formal language and the message clashed with the formal language in the description