### PR TITLE
Force name.surname@tu-dortmund.de format for mails

### DIFF
--- a/member_database/events/__init__.py
+++ b/member_database/events/__init__.py
@@ -126,10 +126,7 @@ def index():
     for event in query:
         if not event.registration_open:
             closed_events.append(event)
-        elif (
-            event.max_participants
-            and event.n_participants >= event.max_participants
-        ):
+        elif event.max_participants and event.n_participants >= event.max_participants:
             full_events.append(event)
         else:
             events.append(event)
@@ -165,9 +162,7 @@ def add_shortlink_route(route, **options):
     def route_name_to_id_decorator(func):
         @wraps(func)
         def call_with_id(shortlink):
-            event = db.one_or_404(
-                db.select(Event).filter_by(shortlink=shortlink)
-            )
+            event = db.one_or_404(db.select(Event).filter_by(shortlink=shortlink))
             return func(event.id)
 
         # have to rename the function, becauce flask has to have
@@ -181,9 +176,7 @@ def add_shortlink_route(route, **options):
 
 
 @events.route("/<int:event_id>/registration/", methods=["GET", "POST"])
-@add_shortlink_route(
-    "/<string:shortlink>/registration/", methods=["GET", "POST"]
-)
+@add_shortlink_route("/<string:shortlink>/registration/", methods=["GET", "POST"])
 def registration(event_id):
     event = db.get_or_404(Event, event_id)
 
@@ -223,9 +216,7 @@ def registration(event_id):
             validate(data, event.registration_schema)
         except ValidationError as e:
             flash(e.message, "danger")
-            return render_template(
-                "events/registration.html", form=form, event=event
-            )
+            return render_template("events/registration.html", form=form, event=event)
 
         person, new_person = get_or_create(
             Person, email=email, defaults={"name": data["name"]}
@@ -244,9 +235,7 @@ def registration(event_id):
         if not new:
             if registration.status_name == "pending":
                 flash(
-                    render_template(
-                        "events/pending.html", registration=registration
-                    ),
+                    render_template("events/pending.html", registration=registration),
                     category="danger",
                 )
             elif registration.status_name == "confirmed":
@@ -258,9 +247,7 @@ def registration(event_id):
                 )
             elif registration.status_name == "waitinglist":
                 flash(
-                    render_template(
-                        "events/waiting.html", registration=registration
-                    ),
+                    render_template("events/waiting.html", registration=registration),
                     category="danger",
                 )
         else:
@@ -332,9 +319,7 @@ def resend_emails():
 
     class ResendForm(FlaskForm):
         email = EmailField(validators=[DataRequired()])
-        submit = SubmitField(
-            "Emails für aktuelle Anmeldungen erneut versenden."
-        )
+        submit = SubmitField("Emails für aktuelle Anmeldungen erneut versenden.")
 
     form = ResendForm()
 
@@ -389,9 +374,7 @@ def participants(event_id):
     participants = db.session.scalars(
         db.select(EventRegistration)
         .filter_by(event_id=event_id)
-        .order_by(
-            EventRegistration.timestamp.is_(None), EventRegistration.timestamp
-        )
+        .order_by(EventRegistration.timestamp.is_(None), EventRegistration.timestamp)
         .options(joinedload(EventRegistration.person))
     )
 
@@ -414,16 +397,12 @@ def participants(event_id):
 
 
 @events.route("/<int:event_id>/write_mail/", methods=["GET", "POST"])
-@add_shortlink_route(
-    "/<string:shortlink>/write_mail/", methods=["GET", "POST"]
-)
+@add_shortlink_route("/<string:shortlink>/write_mail/", methods=["GET", "POST"])
 @access_required("write_email")
 def write_mail(event_id):
     event = Event.query.get(event_id)
 
-    form = SendMailForm(
-        name=current_user.person.name, email=current_user.person.email
-    )
+    form = SendMailForm(name=current_user.person.name, email=current_user.person.email)
     n_participants = get_n_participants(event)
 
     if n_participants == 0:
@@ -486,9 +465,7 @@ def confirmation(token):
     registration = db.session.get(EventRegistration, registration_id)
     event = registration.event
     n_participants = get_n_participants(event)
-    booked_out = (
-        event.max_participants and n_participants >= event.max_participants
-    )
+    booked_out = event.max_participants and n_participants >= event.max_participants
 
     log.info(f"Confirmation for {event} by {person} ({registration})")
 
@@ -536,9 +513,7 @@ def confirmation(token):
         registration.event.registration_schema,
         additional_fields={
             "name": StringField("Name", [DataRequired()]),
-            "email": EmailField(
-                "Email", [DataRequired()], render_kw={"disabled": ""}
-            ),
+            "email": EmailField("Email", [DataRequired()], render_kw={"disabled": ""}),
         },
     )
     form = Form(data={**registration.data, "email": person.email})


### PR DESCRIPTION
Too many people have tried registering with `smxxxx@tu-dortmund.de` mails. This PR updates the regex pattern and forces mails to adhere to the `name.surname@tu-dortmund.de` format.

Also minor formatting updates from pre-commit.